### PR TITLE
Reduce time taken to run Hipcheck

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1189,7 +1189,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hipcheck"
-version = "3.7.0"
+version = "3.7.0-1-lineaje"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/hipcheck/Cargo.toml
+++ b/hipcheck/Cargo.toml
@@ -6,7 +6,7 @@ Automatically assess and score software packages for supply chain risk.
 keywords = ["security", "sbom"]
 categories = ["command-line-utilities", "development-tools"]
 readme = "../README.md"
-version = "3.7.0-1a-lineaje"
+version = "3.7.0-1-lineaje"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://mitre.github.io/hipcheck"

--- a/hipcheck/src/cli.rs
+++ b/hipcheck/src/cli.rs
@@ -417,6 +417,14 @@ pub struct CheckArgs {
 	#[clap(long = "ref")]
 	pub refspec: Option<String>,
 
+	/// The URL value of the target that should be used instead of automatically determining it and set in the report as well
+	#[clap(long = "url-value")]
+	pub url_value: Option<String>,
+
+	/// The path of the local folder where Repo is checked out for NPM, Maven and PyPI packages
+	#[clap(long = "pkg-repo-local-path")]
+	pub pkg_repo_local_path: Option<String>,
+
 	#[clap(subcommand)]
 	command: Option<CheckCommand>,
 
@@ -503,6 +511,8 @@ impl ToTargetSeed for CheckArgs {
 		let target = TargetSeed {
 			kind,
 			refspec: self.refspec.clone(),
+			url_value: self.url_value.clone(),
+			pkg_repo_local_path: self.pkg_repo_local_path.clone(),
 		};
 		// Validate
 		if let Some(refspec) = &target.refspec {
@@ -643,6 +653,7 @@ impl ToTargetSeedKind for CheckRepoArgs {
 				Ok(TargetSeedKind::LocalRepo(LocalGitRepo {
 					path,
 					git_ref: "".to_owned(),
+					git_url: "".to_owned(),
 				}))
 			} else {
 				Err(hc_error!("Provided target repository could not be identified as either a remote url or path to a local file"))

--- a/hipcheck/src/main.rs
+++ b/hipcheck/src/main.rs
@@ -179,6 +179,8 @@ fn cmd_print_weights(config: &CliConfig) -> Result<()> {
 				known_remote: None,
 			}),
 			refspec: Some("HEAD".to_owned()),
+			url_value: Some("https://github.com/mitre/hipcheck.git".to_owned()),
+			pkg_repo_local_path: Some("".to_owned()),
 		},
 		config.config().map(ToOwned::to_owned),
 		config.cache().map(ToOwned::to_owned),

--- a/hipcheck/src/report/mod.rs
+++ b/hipcheck/src/report/mod.rs
@@ -42,6 +42,9 @@ pub struct Report {
 	/// The HEAD commit hash of the repository during analysis.
 	pub repo_head: Arc<String>,
 
+	/// The URL of the repository being analyzed.
+	pub repo_url: Arc<String>,
+
 	/// The version of Hipcheck used to analyze the repo.
 	pub hipcheck_version: String,
 
@@ -64,7 +67,7 @@ pub struct Report {
 impl Report {
 	/// Get the repository that was analyzed.
 	pub fn analyzed(&self) -> String {
-		format!("{} ({})", self.repo_name, self.repo_head)
+		format!("{} ({}) ({})", self.repo_name, self.repo_head, self.repo_url)
 	}
 
 	/// Get the version of Hipcheck used for the analysis.

--- a/hipcheck/src/report/report_builder.rs
+++ b/hipcheck/src/report/report_builder.rs
@@ -364,6 +364,7 @@ impl<'sess> ReportBuilder<'sess> {
 	pub fn build(self) -> Result<Report> {
 		let repo_name = self.session.name();
 		let repo_head = self.session.head();
+		let repo_url = self.session.repo_url();
 		let hipcheck_version = self.session.hc_version().to_string();
 		let analyzed_at = Timestamp::from(self.session.started_at());
 		let passing = self.passing;
@@ -413,6 +414,7 @@ impl<'sess> ReportBuilder<'sess> {
 		let report = Report {
 			repo_name,
 			repo_head,
+			repo_url,
 			hipcheck_version,
 			analyzed_at,
 			passing,

--- a/hipcheck/src/source/query.rs
+++ b/hipcheck/src/source/query.rs
@@ -20,8 +20,10 @@ pub trait SourceQuery: salsa::Database {
 	fn head(&self) -> Arc<String>;
 	/// Returns the repository name
 	fn name(&self) -> Arc<String>;
-	/// Returns the repository url
+	/// Returns the repository url passed as an option
 	fn url(&self) -> Option<Arc<String>>;
+	/// Returns the repository url used for actual analysis
+	fn repo_url(&self) -> Arc<String>;
 }
 
 /// Derived query implementations
@@ -66,4 +68,9 @@ fn name(db: &dyn SourceQuery) -> Arc<String> {
 
 fn url(db: &dyn SourceQuery) -> Option<Arc<String>> {
 	Some(Arc::new(db.remote()?.url.to_string()))
+}
+
+fn repo_url(db: &dyn SourceQuery) -> Arc<String> {
+	let target = db.target();
+	Arc::new(target.local.git_url.clone())
 }

--- a/hipcheck/src/target/types.rs
+++ b/hipcheck/src/target/types.rs
@@ -43,6 +43,9 @@ pub struct LocalGitRepo {
 
 	/// The Git ref we're referring to.
 	pub git_ref: String,
+
+	/// The Git URL we're referring to.
+	pub git_url: String,
 }
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, JsonSchema)]
 pub struct Package {
@@ -126,6 +129,10 @@ pub enum TargetSeedKind {
 pub struct TargetSeed {
 	pub kind: TargetSeedKind,
 	pub refspec: Option<String>,
+	// Repo URL for this Package
+	pub url_value: Option<String>,
+	// Path of Local folder where repo of this Package is available
+	pub pkg_repo_local_path: Option<String>,
 }
 
 impl Display for TargetSeedKind {


### PR DESCRIPTION
Set the following attributes for a Repo, NPM, Maven and PyPI package
- "url-value", a new attribute to indicate the Git Repo URL
- "ref", a new attribute to indicate the Git Tag or Branch name Set "pkg-repo-local-path" to indicate the local Folder where Repo is checked out for NPM, Maven and PyPI packages
For Repo type inputs, code to copy the repo folder to "clones" directory has been disable to save time, and resource
These significantly reduce the time taken by Hipcheck by reusing existing repo directory, avoiding unnecessary copy and Package lookups